### PR TITLE
Linux fixes and support for 'NAME' type columns

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -322,6 +322,7 @@ assign_member :: (name: string, info: *Type_Info, slot: *u8, col_type: Pq_Type, 
         case .CHAR; #through;
         case .BPCHAR; #through;
         case .VARCHAR; #through;
+        case .NAME; #through;
         case .TEXT;
             val: string;
             val.data = data;

--- a/module.jai
+++ b/module.jai
@@ -195,8 +195,11 @@ get_results :: (query_res: *PGresult, $T: Type, $ignore_unknown := false) -> [] 
         results.data = xx raw_result.data;
         results.count = raw_result.count * size_of(u8) / size_of(T);
         return results, success;
-    } else 
-        return xx raw_result, success;
+    } else {
+        results.data = xx raw_result.data;
+        results.count = raw_result.count;
+        return results, success;
+    }
 }
 
 get_results :: (query_res: *PGresult, info: *Type_Info, ignore_unknown := false) -> Array_View_64, success: bool {

--- a/pq_types.jai
+++ b/pq_types.jai
@@ -12,6 +12,7 @@ Pq_Type :: enum Oid {
 	BOOL            :: 16;
 	BYTEA           :: 17;
 	CHAR            :: 18;
+        NAME            :: 19;
 	INT8            :: 20;
 	INT2            :: 21;
 	INT4            :: 23;


### PR DESCRIPTION
This PR does two things:

  * Make compiling on Linux work and returning with get_results work with correct data.
  * Adds support for the "NAME" field type (id 19).