### PR TITLE
Add support for Postgres UUID type

### DIFF
--- a/examples/example.jai
+++ b/examples/example.jai
@@ -26,7 +26,8 @@ main :: () {
             -- '2023-10-24'::date real_date_apollo,          -- Test writing date into Apollo_Time
             'Hello, Sailor!'::bytea sailor_bytes,         -- Test [] case
             'Hello, Sailor!'::bytea sailor_bytes_dynamic, -- Test [..] case
-            'Hello, Sailor!'::bytea sailor_bytes_fixed    -- Test [n] case
+            'Hello, Sailor!'::bytea sailor_bytes_fixed,    -- Test [n] case
+            '01951a87-c21c-726c-ba20-e0da37db52cf'::UUID -- UUID (which is a [16]u8) test case
     END
 
     results: [] Test;
@@ -59,8 +60,19 @@ main :: () {
     assert(cast(string) result.sailor_bytes         == "Hello, Sailor!");
     assert(cast(string) result.sailor_bytes_dynamic == "Hello, Sailor!");
     assert(cast(string) result.sailor_bytes_fixed   == "Hello, Sailor!");
+    // These bytes are the UUIDv7: 01951a87-c21c-726c-ba20-e0da37db52cf
+    assert(uuid_equal(result.uuid, u8.[1, 149, 26, 135, 194, 28, 114, 108, 186, 32, 224, 218, 55, 219, 82, 207]));
     log("% vs % vs %", result.time_wo_tz, result.time_with_tz, result.time_utc);
     log("ALL OK");
+}
+
+UUID :: [16]u8;
+
+// UUIDs are just two s64 values, so equality is simply comparing each
+// of the two s64 values to each other from u1 and u2
+uuid_equal :: (u1: UUID, u2: UUID) -> bool {
+    a, b := u1.([2]s64,force), u2.([2]s64,force);
+    return a[0] == b[0] && a[1] == b[1];
 }
 
 Test :: struct {
@@ -90,6 +102,7 @@ Test :: struct {
     sailor_bytes:         [] u8;
     sailor_bytes_dynamic: [..] u8;
     sailor_bytes_fixed:   [14] u8;
+    uuid: UUID;
 }
 
 #import,file "../module.jai";

--- a/examples/example.jai
+++ b/examples/example.jai
@@ -75,6 +75,26 @@ uuid_equal :: (u1: UUID, u2: UUID) -> bool {
     return a[0] == b[0] && a[1] == b[1];
 }
 
+uuid_to_string :: (uuid: UUID) -> string {
+
+    push_context {
+
+        context.print_style.default_format_int.base = 16;
+        context.print_style.default_format_int.minimum_digits = 2;
+
+        formatted := sprint("%0%0%0%0-%0%0-%0%0-%0%0-%0%0%0%0%0%0",
+            uuid[0], uuid[1], uuid[2], uuid[3],
+            uuid[4], uuid[5],
+            uuid[6], uuid[7],
+            uuid[8], uuid[9],
+            uuid[10], uuid[11],
+            uuid[12], uuid[13], uuid[14], uuid[15],
+        );
+
+        return formatted;
+    }
+}
+
 Test :: struct {
     int2:                 int;
     int4:                 int;

--- a/module.jai
+++ b/module.jai
@@ -412,6 +412,7 @@ assign_member :: (name: string, info: *Type_Info, slot: *u8, col_type: Pq_Type, 
                 return write_integer(col, name, info, slot, col_type, val);
             }
 
+        case .UUID; #through;
         case .BYTEA;
             if info.type == .ARRAY {
                 array_info := cast(*Type_Info_Array) info;

--- a/module.jai
+++ b/module.jai
@@ -412,7 +412,7 @@ assign_member :: (name: string, info: *Type_Info, slot: *u8, col_type: Pq_Type, 
                 return write_integer(col, name, info, slot, col_type, val);
             }
 
-        case .UUID; #through;
+        case .UUID; #through; // UUIDs are simplye [16]u8, returned from postgres as a byte array
         case .BYTEA;
             if info.type == .ARRAY {
                 array_info := cast(*Type_Info_Array) info;

--- a/readme.md
+++ b/readme.md
@@ -74,4 +74,5 @@ Using a Pool allocator around your `execute` calls might be a good idea.
 * `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`
 * `BYTEA`
 * `OID`
+* `UUID`
 * Custom enum types (`CREATE TYPE … AS ENUM`), which can be parsed into `string` or `enum` member fields.


### PR DESCRIPTION
Hello Raphael!

Just as with Jaison (and other things), thanks a lot for this great contribution to the Jai community. We are starting to use this on our production code, and hopefully we will try to contribute back if we add things, based on our needs.

For now, we need UUID support, which Postgres supports and stores as a simple array of `[16]u8`. As such, I have simply added a `#through` for the UUID type to use the `BYTEA` type, since they are internally the same thing, and represented in code the same way. I have also updated the example, and added `uuid_to_string` and `uuid_equal`  procedures to the example, which I expect will be helpful to people.

I was also thinking we can maybe update the readme to mention which shared libraries are needed to use this module, which is to put `libpg.lib` with the bindings, and to have the following dlls with your exe or in your path: `libcrypto-3-x64.dll`, `libiconv-2.dll`, `libintl-9.dll`, `libpq.dll`, `libssl-3-x64.dll`, but didn't want to pollute the PR with things maybe you don't think are suitable. If you like, I can update the PR to also include an updated readme :)

Side note: Am on the latest beta, 0.2.009, and when trying to run `jai generate.jai`, I get an error because `GENERATOR_DEFAULT_SYSTEM_INCLUDE_PATH` isn't found, but I see in an old changelog its supposed to be there? To make the generator work, I used this which I found on the beta discord:
```
GENERATOR_DEFAULT_SYSTEM_INCLUDE_PATH :: #run (() -> string {
    this_file := #location().fully_pathed_filename;
    this_module := path_strip_filename(this_file);
    include_path := sprint("%bin/clang/19/include", this_module);
    return include_path;
})();
```

Wish you a nice day!